### PR TITLE
Add index annotation to leaves, enabling substring offset searches

### DIFF
--- a/Data/SuffixTree.hs
+++ b/Data/SuffixTree.hs
@@ -382,6 +382,10 @@ countLeaves :: STree a -> Int
 countLeaves (Leaf _) = 1
 countLeaves (Node es) = L.foldl' (\v (_, t) -> countLeaves t + v) 0 es
 
+listLeaves :: STree a -> [LeafValue]
+listLeaves (Leaf l) = [l]
+listLeaves (Node es) = concat $ L.foldl' (\v (_, t) -> listLeaves t : v) [] es
+
 -- | /O(n + r)/. Count the number of times a sequence is repeated
 -- in the input sequence that was used to construct the suffix tree.
 --
@@ -389,3 +393,6 @@ countLeaves (Node es) = L.foldl' (\v (_, t) -> countLeaves t + v) 0 es
 -- the number of times /r/ the sequence is repeated.
 countRepeats :: (Eq a) => [a] -> STree a -> Int
 countRepeats s t = maybe 0 countLeaves (findTree s t)
+
+listRepeats :: (Eq a) => [a] -> STree a -> [LeafValue]
+listRepeats s t = maybe [] listLeaves (findTree s t)

--- a/Data/SuffixTree.hs
+++ b/Data/SuffixTree.hs
@@ -418,3 +418,14 @@ countFrequencies t = tail . snd . go id $ t
            go pp (Node es) =
                let (ns, xs) = unzip . map (\(p, t) -> go (pp . (p++)) t) $ es
                in (sum ns, (pp [], sum ns):concat xs)
+
+suffixArray :: STree a -> [Int]
+suffixArray t = l : map ((l-) . length . fst) li
+    where li = toList t
+          l = length li + 1
+
+lcp :: STree a -> [Int]
+lcp t = 0 : go 0 t
+    where go n (Leaf _) = []
+          go n (Node es) = tail . concatMap (f n) $ es
+          f n (p, t) = n: go (n + length p) t

--- a/Data/SuffixTree.hs
+++ b/Data/SuffixTree.hs
@@ -307,7 +307,7 @@ elem xs (Node es) = any pfx es
 --
 -- Here is an example:
 --
--- >> find "ssip" (construct "mississippi")
+-- >> findEdge "ssip" (construct "mississippi")
 -- >Just ((mkPrefix "ppi",Leaf),1)
 --
 -- This indicates that the edge @('mkPrefix' \"ppi\",'Leaf')@ matches,

--- a/Data/SuffixTree.hs
+++ b/Data/SuffixTree.hs
@@ -75,7 +75,7 @@ import qualified Data.ByteString as SB
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.List as L
 import Data.Maybe (listToMaybe, mapMaybe)
-import Text.Regex.TDFA (=~)
+import Text.Regex.TDFA ((=~))
 
 -- | The length of a prefix list.  This type is formulated to do cheap
 -- work eagerly (to avoid constructing a pile of deferred thunks),
@@ -409,3 +409,12 @@ match "" _ = []
 match regex t = filter (not . null . fst) (map m $ toList t)
     where r = if head regex == '^' then regex else '^':regex
           m x = (fst x =~ r, snd x) :: (String, LeafValue)
+
+countFrequencies :: STree a -> [([a], Int)]
+countFrequencies  (Leaf _) = []
+countFrequencies (Node []) = []
+countFrequencies t = tail . snd . go id $ t
+     where go _ (Leaf _) = (1, [])
+           go pp (Node es) =
+               let (ns, xs) = unzip . map (\(p, t) -> go (pp . (p++)) t) $ es
+               in (sum ns, (pp [], sum ns):concat xs)

--- a/Data/SuffixTree.hs
+++ b/Data/SuffixTree.hs
@@ -1,5 +1,4 @@
 {- Fastest when compiled as follows: ghc -O2 -optc-O3 -funbox-strict-fields -}
-
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.SuffixTree
@@ -33,6 +32,8 @@
 -- Estimates are given for performance.  The value /k/ is a constant;
 -- /n/ is the length of a query string; and /t/ is the number of
 -- elements (nodes and leaves) in a suffix tree.
+
+{-# LANGUAGE DeriveFunctor, DeriveFoldable, DeriveTraversable #-}
 
 module Data.SuffixTree
     (
@@ -129,7 +130,7 @@ data PreSTree a = PreNode [PreEdge a]
 
 data STree a = Node [Edge a]
              | Leaf LeafValue
-               deriving (Show)
+               deriving (Show, Functor, Foldable, Traversable)
 
 smap :: (a -> b) -> PreSTree a -> PreSTree b
 smap _ (PreLeaf n) = PreLeaf n

--- a/Data/SuffixTree.hs
+++ b/Data/SuffixTree.hs
@@ -34,6 +34,7 @@
 -- elements (nodes and leaves) in a suffix tree.
 
 {-# LANGUAGE DeriveFunctor, DeriveFoldable, DeriveTraversable #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 module Data.SuffixTree
     (
@@ -74,6 +75,7 @@ import qualified Data.ByteString as SB
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.List as L
 import Data.Maybe (listToMaybe, mapMaybe)
+import Text.Regex.TDFA (=~)
 
 -- | The length of a prefix list.  This type is formulated to do cheap
 -- work eagerly (to avoid constructing a pile of deferred thunks),
@@ -401,3 +403,9 @@ toList :: STree a -> [([a], LeafValue)]
 toList (Leaf l) = [([], l)]
 toList (Node es) = concatMap (\(p,t) -> map (combine p) (toList t)) es
     where combine p (a, b) = (p ++ a, b)
+
+match :: String -> STree Char -> [(String, LeafValue)]
+match "" _ = []
+match regex t = filter (not . null . fst) (map m $ toList t)
+    where r = if head regex == '^' then regex else '^':regex
+          m x = (fst x =~ r, snd x) :: (String, LeafValue)

--- a/Data/SuffixTree.hs
+++ b/Data/SuffixTree.hs
@@ -396,3 +396,8 @@ countRepeats s t = maybe 0 countLeaves (findTree s t)
 
 listRepeats :: (Eq a) => [a] -> STree a -> [LeafValue]
 listRepeats s t = maybe [] listLeaves (findTree s t)
+
+toList :: STree a -> [([a], LeafValue)]
+toList (Leaf l) = [([], l)]
+toList (Node es) = concatMap (\(p,t) -> map (combine p) (toList t)) es
+    where combine p (a, b) = (p ++ a, b)

--- a/suffixtree.cabal
+++ b/suffixtree.cabal
@@ -19,6 +19,7 @@ Library
   Build-Depends:     base >= 3 && < 5,
                      bytestring,
                      containers
+                     regex-tdfa >= 1.3.1.0
   Exposed-Modules:   Data.SuffixTree
   GHC-Options:       -Wall -funbox-strict-fields -fno-warn-incomplete-patterns
 


### PR DESCRIPTION
This pull request alters the `SuffixTree` data structure so that the leaves are numbered, as is standard for suffix trees.

In trees built with `construct` and `constructWith`, each leaf number indicates the offset of that leaf's path from the start of the string used to generate the tree. For example, in a tree constructed from the string "banana$", the leaf with the path "nana$" is numbered 2.

This adds index information to substring searches, so that you can tell where the found substring occurs in the original string.